### PR TITLE
Switch the Dockerfile to the maintenance branch

### DIFF
--- a/devops/docker/girder/Dockerfile
+++ b/devops/docker/girder/Dockerfile
@@ -1,4 +1,4 @@
-FROM girder/girder:latest-py3
+FROM girder/girder:2.x-maintenance-py3
 
 # Enable proxy support
 COPY ./devops/docker/girder/girder.local.conf /girder/girder/conf/girder.local.cfg


### PR DESCRIPTION
This application is built on 2.x, and will need some porting to adapt to
master. For now switch to the maintennance py3 image as a base.